### PR TITLE
Add support to flatten the MDC fields

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/loggingjson/Config.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/Config.java
@@ -98,7 +98,7 @@ public class Config {
          * Options for mdc.
          */
         @ConfigItem
-        public FieldConfig mdc;
+        public MDCConfig mdc;
         /**
          * Options for ndc.
          */
@@ -133,6 +133,25 @@ public class Config {
          */
         @ConfigItem
         public Optional<Boolean> enabled;
+    }
+
+    @ConfigGroup
+    public static class MDCConfig {
+        /**
+         * Used to change the json key for the field.
+         */
+        @ConfigItem
+        public Optional<String> fieldName;
+        /**
+         * Enable or disable the field.
+         */
+        @ConfigItem
+        public Optional<Boolean> enabled;
+        /**
+         * Will write the values at the top level of the JSON log object.
+         */
+        @ConfigItem
+        public Optional<Boolean> flatFields;
     }
 
     @ConfigGroup

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/JsonWritingUtils.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/JsonWritingUtils.java
@@ -11,9 +11,9 @@ public class JsonWritingUtils {
      * Writes entries of the map as fields.
      */
     public static void writeMapEntries(JsonGenerator generator, Map<?, ?> map) throws IOException {
-        if (map != null) {
+        if (map != null && !map.isEmpty()) {
             for (Map.Entry<?, ?> entry : map.entrySet()) {
-                if (entry.getKey() != null && entry.getValue() != null) {
+                if (entry.getKey() != null && entry.getValue() != null && shouldWriteField(entry.getKey().toString())) {
                     generator.writeFieldName(entry.getKey().toString());
                     generator.writeObject(entry.getValue());
                 }

--- a/runtime/src/main/java/io/quarkiverse/loggingjson/providers/MDCJsonProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingjson/providers/MDCJsonProvider.java
@@ -13,16 +13,22 @@ import io.quarkiverse.loggingjson.JsonWritingUtils;
 public class MDCJsonProvider implements JsonProvider, Enabled {
 
     private final String fieldName;
-    private final Config.FieldConfig config;
+    private final Boolean flatFields;
+    private final Config.MDCConfig config;
 
-    public MDCJsonProvider(Config.FieldConfig config) {
+    public MDCJsonProvider(Config.MDCConfig config) {
         this.config = config;
         this.fieldName = config.fieldName.orElse("mdc");
+        this.flatFields = config.flatFields.orElse(false);
     }
 
     @Override
     public void writeTo(JsonGenerator generator, ExtLogRecord event) throws IOException {
-        JsonWritingUtils.writeMapStringFields(generator, fieldName, event.getMdcCopy());
+        if (flatFields) {
+            JsonWritingUtils.writeMapEntries(generator, event.getMdcCopy());
+        } else {
+            JsonWritingUtils.writeMapStringFields(generator, fieldName, event.getMdcCopy());
+        }
     }
 
     @Override

--- a/runtime/src/test/java/io/quarkiverse/loggingjson/providers/MDCJsonProviderJsonbTest.java
+++ b/runtime/src/test/java/io/quarkiverse/loggingjson/providers/MDCJsonProviderJsonbTest.java
@@ -21,9 +21,10 @@ public class MDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testDefaultConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
+        final Config.MDCConfig config = new Config.MDCConfig();
         config.fieldName = Optional.empty();
         config.enabled = Optional.empty();
+        config.flatFields = Optional.empty();
         final MDCJsonProvider provider = new MDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -42,9 +43,10 @@ public class MDCJsonProviderJsonbTest extends JsonProviderBaseTest {
 
     @Test
     void testCustomConfig() throws Exception {
-        final Config.FieldConfig config = new Config.FieldConfig();
+        final Config.MDCConfig config = new Config.MDCConfig();
         config.fieldName = Optional.of("m");
         config.enabled = Optional.of(false);
+        config.flatFields = Optional.of(false);
         final MDCJsonProvider provider = new MDCJsonProvider(config);
 
         final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
@@ -58,6 +60,34 @@ public class MDCJsonProviderJsonbTest extends JsonProviderBaseTest {
         Assertions.assertEquals(Arrays.asList("mdcKey1", "mdcKey2"), ImmutableList.copyOf(mdc.fieldNames()));
         Assertions.assertEquals("mdcValue1", mdc.get("mdcKey1").asText());
         Assertions.assertEquals("mdcValue2", mdc.get("mdcKey2").asText());
+
+        Assertions.assertFalse(provider.isEnabled());
+
+        config.enabled = Optional.of(true);
+        Assertions.assertTrue(new MDCJsonProvider(config).isEnabled());
+    }
+
+    @Test
+    void testFlatCustomConfig() throws Exception {
+        final Config.MDCConfig config = new Config.MDCConfig();
+        config.fieldName = Optional.of("m");
+        config.enabled = Optional.of(false);
+        config.flatFields = Optional.of(true);
+        final MDCJsonProvider provider = new MDCJsonProvider(config);
+
+        final ExtLogRecord event = new ExtLogRecord(Level.ALL, "", "");
+        event.putMdc("mdcKey1", "mdcValue1");
+        event.putMdc("mdcKey2", "mdcValue2");
+        final JsonNode result = getResultAsJsonNode(provider, event);
+
+        final JsonNode mdc = result.findValue("m");
+        Assertions.assertNull(mdc);
+
+        final JsonNode mdcValue1 = result.findValue("mdcKey1");
+        Assertions.assertEquals(mdcValue1.textValue(), "mdcValue1");
+
+        final JsonNode mdcValue2 = result.findValue("mdcKey2");
+        Assertions.assertEquals(mdcValue2.textValue(), "mdcValue2");
 
         Assertions.assertFalse(provider.isEnabled());
 


### PR DESCRIPTION
Currently the MDC will be written like this by default:
```
...
  "threadName": "executor-thread-1",
  "threadId": 124,
  "mdc": {
    "spanId": "d33c516e5617c3ba",
    "parentId": "0",
    "accountId": "",
    "userId": "",
    "traceId": "d33c516e5617c3ba",
    "sampled": "true",
    "tid": ""
  },
  "hostName": "sagan",
...
```
This PR continues to allow this by default but adds support to flatten the MDC fiels like:
```
...
  "threadName": "executor-thread-1",
  "threadId": 124,
  "spanId": "d33c516e5617c3ba",
  "parentId": "0",
  "accountId": "",
  "userId": "",
  "traceId": "d33c516e5617c3ba",
  "sampled": "true",
  "tid": ""
  "hostName": "sagan",
...
```
This happens because some organizations will  ingest all the field values as strings, leaving un-indexed the fields inside the mdc